### PR TITLE
Allow interfaces as request object class

### DIFF
--- a/src/Describer/DocumentedRouteDescriber.php
+++ b/src/Describer/DocumentedRouteDescriber.php
@@ -42,7 +42,7 @@ final class DocumentedRouteDescriber implements DescriberInterface
         private readonly LoggerInterface $logger,
         ?string $requestObjectClass = null,
     ) {
-        if (null !== $requestObjectClass && !class_exists($requestObjectClass)) {
+        if (null !== $requestObjectClass && !(class_exists($requestObjectClass) || interface_exists($requestObjectClass))) {
             throw new \InvalidArgumentException(sprintf('Class %s does not exist.', $requestObjectClass));
         } elseif (null !== $requestObjectClass) {
             $this->requestObjectReflectionClass = new \ReflectionClass($requestObjectClass);


### PR DESCRIPTION
When using following configuration
```
fusonic_api_documentation:
  request_object_class: App\Infra\InputOutputMapping\Input
```
and the input being an interface i would get `InvalidArgumentException` with message `Class App\Infra\InputOutputMapping\Input does not exist.`

With this fix, it work flawlessly.